### PR TITLE
Add standalone /subscribe page

### DIFF
--- a/content/subscribe.md
+++ b/content/subscribe.md
@@ -1,0 +1,39 @@
+---
+title: "Subscribe to the Apertus Newsletter"
+minimal: true
+sitemap:
+  disable: true
+---
+
+<h2 style="text-align: center; margin-top: 3rem;">Stay Updated</h2>
+
+<p style="text-align: center; color: #6b7280; margin-bottom: 1.5rem;">
+  Our newsletter will keep you on top of Apertus releases, our team's research, and community news.
+</p>
+
+<div style="max-width: 500px; margin: 0 auto 4rem auto;">
+    <form class="inf-form" method="post"
+          action="https://newsletter.infomaniak.com/v3/api/1/newsletters/webforms/23060/submit"
+          style="display: flex; gap: 0.75rem; flex-wrap: wrap; justify-content: center;">
+        <input type="email" name="email" style="display:none" />
+        <input type="hidden" name="key" value="eyJpdiI6ImlzNTJmenU3TXhreU1hT0JSeGhjZXNkcU5IaU1PTkcrdTh4eWFGdUVwblk9IiwibWFjIjoiZGY4OTBiZmFlMDI0NDU3NGMyYTc5YTEwMjI3NjY5YWYyZGU4ZmYyYzAxODFjZjBmNDgwNjA0MjQzYzc4YjhiZCIsInZhbHVlIjoiQnRnazhCUUUzamRSQUJiUmNPQWtNZHV6Rlc1amt4Tm9nMVZkSytTbXhjOD0ifQ==">
+        <input type="hidden" name="webform_id" value="23060">
+        <div class="inf-main_3d8fe53b02cd5791092fcb7cad6d117c">
+          <div class="inf-success" style="display:none">
+            <h4>A confirmation email has been sent to you. Please check your inbox.</h4>
+            <p> <a href="#" class="inf-btn">&laquo;</a> </p>
+          </div>
+          <div class="inf-content">
+            <div class="inf-input inf-input-text" style="display:inline">
+              <input type="email" name="inf[1]" data-inf-meta="1" data-inf-error="" required="required" placeholder="Email *"
+                     style="flex: 1; min-width: 250px; padding: 0.75rem 1rem; border: 2px solid #c0c4cc; border-radius: 8px; font-size: 1rem;">
+            </div>
+            <script src="https://eu.altcha.org/js/latest/altcha.min.js" type="module" defer></script> <altcha-widget hidelogo hidefooter floating challengeurl="https://newsletter.infomaniak.com/v3/altcha-challenge" ></altcha-widget> <script src="https://newsletter.storage5.infomaniak.com/mcaptcha/altcha.js" defer> </script> <script type="text/javascript" src="https://newsletter.infomaniak.com/v3/static/webform_index.js?v=1770495352"></script>
+            <div class="inf-submit" style="display: inline">
+              <button type="submit" style="padding: 0.75rem 1.5rem; background-color: #49BED8; color: white; border: none; border-radius: 8px; font-size: 1rem; font-weight: 500; cursor: pointer;">Subscribe</button>
+            </div>
+            <div class="inf-rgpd" style="font-size:0.8rem;opacity:0.7">Your email address will only be used to send you our newsletter and information about our activities. You can unsubscribe at any time using the link in our emails.</div>
+          </div>
+        </div>
+    </form>
+</div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main>
   {{/* Navbar */}}
-  {{ partial "navbar.html" }}
+  {{ if not .Params.minimal }}{{ partial "navbar.html" }}{{ end }}
 
   {{ if .Params.featured_image }}
     <header class="mb-8 mt-5 pt-5 pb-5">


### PR DESCRIPTION
Adds a /subscribe page with the newsletter signup form for direct signups via QR code. No navbar, just the form. Not linked from the main site.