### PR TITLE
CNAME domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+apertus-ai.org.


### PR DESCRIPTION
Redirect to the new domain apertus-ai.org