### PR TITLE
Fix Hugo build failure from Locale field on pinned 0.155.0

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.Locale }}" dir="ltr">
+<html lang="{{ site.Language.LanguageCode }}" dir="ltr">
     {{- partial "head.html" . -}}
     <body>
         <div id="content">


### PR DESCRIPTION
## Summary
- Deploy CI (`Build and deploy`) has been failing on every push to `main` since PR #28, and continued failing through PR #29 and #30 (unrelated changes, they just built on top of broken `main`).
- Root cause: `layouts/_default/baseof.html` uses `site.Language.Locale`, added in commit 7b724bd ("Fix configuration of button"). That field doesn't exist on `*langs.Language` in Hugo v0.155.0, which is what `.github/workflows/hugo.yaml` pins (`HUGO_VERSION: 0.155.0`). Build error:
  ```
  ERROR error building site: render: [en v1.0.0 guest] failed to render pages: render of "content/_index.md" failed: "layouts/_default/baseof.html:2:15": execute of template failed: template: index.html:2:15: executing "index.html" at <site>: can't evaluate field Locale in type *langs.Language
  ```
- Fix: use `site.Language.LanguageCode` instead, which exists on 0.155.0 and resolves to the language key (`en`) since `hugo.toml` has no `languageCode` set.

## Test plan
- [x] Built locally with `hugo --gc --minify --baseURL "http://apertus-ai.org/"` — site builds successfully, `<html lang=en dir=ltr>` renders correctly.
- [ ] CI `Build and deploy` workflow passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)