### PR TITLE
Rename Swiss AI Charter to Apertus Charter

### DIFF
--- a/assets/jsconfig.json
+++ b/assets/jsconfig.json
@@ -1,9 +1,10 @@
 {
  "compilerOptions": {
+  "baseUrl": ".",
   "paths": {
    "*": [
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2@v2.21100.20000/package/dist/cjs/*",
-    "../../../../Library/Caches/hugo_cache/modules/filecache/modules/pkg/mod/github.com/twbs/bootstrap@v5.3.8+incompatible/js/*"
+    "../../../../../../../home/chuck/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2@v2.21100.20000/package/dist/cjs/*",
+    "../../../../../../../home/chuck/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/twbs/bootstrap@v5.3.8+incompatible/js/*"
    ]
   }
  }

--- a/content/articles/2026-03-sme-circle/index.md
+++ b/content/articles/2026-03-sme-circle/index.md
@@ -41,7 +41,7 @@ SMEs don't just want a model; they want a solution they can integrate into exist
 
 ### 3\. Governance and Ethics
 
-The participants are not just looking for technology; they are looking for values. There is a strong alignment with the Swiss AI Charter, with participants emphasizing the need for AI that supports public good, reduces bias, and operates with transparency. Questions about the EU AI Act, compliance frameworks (MITRE, OWASP), and explainable AI (XAI) dominated the technical queries. The community wants to know how decisions are made, not just what the decisions are.
+The participants are not just looking for technology; they are looking for values. There is a strong alignment with the Apertus Charter, with participants emphasizing the need for AI that supports public good, reduces bias, and operates with transparency. Questions about the EU AI Act, compliance frameworks (MITRE, OWASP), and explainable AI (XAI) dominated the technical queries. The community wants to know how decisions are made, not just what the decisions are.
 
 ### 4\. Community and Collaboration
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -51,7 +51,7 @@ Many organizations are currently piloting solutions with the model, and we will 
 <h4>How is Apertus aligned?</h4>
 <p>Apertus was trained with ethical and safety principles to align with Swiss values and EU AI Act goals (e.g., transparency, fairness, human oversight). 
 While we strive to minimize bias, users should be aware of inherent biases in language data and test for fairness in their applications.
-See the <a href="/pages/charter">Swiss AI Charter</a> for details.
+See the <a href="/pages/charter">Apertus Charter</a> for details.
 </div>
 
 <div class="faq-item">

--- a/content/docs/tech/fine-tuning.md
+++ b/content/docs/tech/fine-tuning.md
@@ -125,7 +125,7 @@ tokenizer = AutoTokenizer.from_pretrained("Apertus-FT/output/apertus_full/")
 ### Safety Considerations
 
 - Avoid training on legally unclear, harmful or sensitive data.
-- Do not try to circumvent guardrails like the [Swiss AI Charter](/pages/charter/).
+- Do not try to circumvent guardrails like the [Apertus Charter](/pages/charter/).
 - Use the [official guidelines](/pages/documentation) for responsible AI development.
 
 See [Rethinking Safety in LLM Fine-tuning](https://arxiv.org/abs/2508.12531) ... and please share your insights!

--- a/content/pages/charter.md
+++ b/content/pages/charter.md
@@ -1,8 +1,8 @@
 ---
-title: "Swiss AI Charter"
+title: "Apertus Charter"
 ---
 
-<p class="section-intro">The Swiss AI Charter defines alignment principles for AI systems developed under the Swiss AI Initiative, rooted in Switzerland's constitutional values and democratic traditions.</p>
+<p class="section-intro">The Apertus Charter defines alignment principles for AI systems developed under the Swiss AI Initiative, rooted in Switzerland's constitutional values and democratic traditions.</p>
 
 <div class="charter-meta">
 <strong>Version 1.0</strong><br>

--- a/content/pages/documentation.md
+++ b/content/pages/documentation.md
@@ -15,7 +15,7 @@ title: "Documentation"
     <p>Terms and conditions for model use</p>
   </a>
   <a href="/pages/charter" class="card" style="text-decoration: none;">
-    <h4>Swiss AI Charter</h4>
+    <h4>Apertus Charter</h4>
     <p>The internal constitution of Apertus</p>
   </a>
   <a href="https://huggingface.co/swiss-ai/Apertus-70B-2509/blob/main/Apertus_EU_Public_Summary.pdf" class="card" style="text-decoration: none;">


### PR DESCRIPTION
Renames the charter to "Apertus Charter" across the site: charter page title and intro, documentation card, FAQ link, fine-tuning guardrails note, and the March SME-circle article.