### PR TITLE
Remove under-construction feedback banner

### DIFF
--- a/layouts/_default/news.html
+++ b/layouts/_default/news.html
@@ -8,12 +8,6 @@
     {{ partial "newsletter.html" }}
   {{ end }}
 
-  <div class="mt-5 mb-0 pt-4 pb-2 alert alert-warning text-center" role="alert">
-      Our new website is under construction: have any feedback?
-      <a href="/feedback">
-          Please let us know!
-      </a>
-  </div>
 
 <div class="container mt-5" style="max-width: 1100px;">
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,12 +8,6 @@
     {{ partial "newsletter.html" }}
   {{ end }}
 
-  <div class="mt-5 mb-0 pt-4 pb-2 alert alert-warning text-center" role="alert">
-      Our new website is under construction: have any feedback?
-      <a href="/feedback">
-          Please let us know!
-      </a>
-  </div>
 
   {{ if .Params.featured_image }}
     <header class="mb-8 mt-5 pt-5 pb-5">


### PR DESCRIPTION
Removes the "Our new website is under construction" alert from the single and news layouts.