### PR TITLE
Replace em dashes across site content

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Apertus"
 mission: "Fully Open Foundation Model for Sovereign AI"
-description: "Developed by the Swiss AI Initiative as a collaborative effort between EPFL, ETH Zurich, and CSCS. Open weights, open data, open science—trained on 15 trillion tokens across 1,000+ languages."
+description: "Developed by the Swiss AI Initiative as a collaborative effort between EPFL, ETH Zurich, and CSCS. Open weights, open data, open science. Trained on 15 trillion tokens across 1,000+ languages."
 hero_primary_label: "Get Started"
 hero_primary_url: "/pages/get-started/"
 hero_secondary_label: "Technical Information"
@@ -12,7 +12,7 @@ hero_secondary_url: "/pages/documentation/"
 
 ### Fully Open
 
-Training data, code, weights, methods, and alignment principles — all documented and reproducible. Apertus is to AI as Open is to Source.
+Training data, code, weights, methods, and alignment principles: all documented and reproducible. Apertus is to AI as Open is to Source.
 
 <--->
 
@@ -24,6 +24,6 @@ Built to meet EU AI Act requirements: the model respects opt-outs, removes PII, 
 
 ### Run for Performance
 
-Competitive with top open models at an equivalent scale of 8B and 70B parameters. Multilingual from day one — trained on 1000+ languages.
+Competitive with top open models at an equivalent scale of 8B and 70B parameters. Multilingual from day one, trained on 1000+ languages.
 
 {{< /columns >}}

--- a/content/articles/2026-02-gpai/index.md
+++ b/content/articles/2026-02-gpai/index.md
@@ -33,7 +33,7 @@ This result has now been featured in [Euractiv](https://www.euractiv.com/news/re
 
 *Screenshot of the [overall evaluation](https://aial.ie/research/gpai-training-transparency/) results, with each model assigned a grade. `A+` is the highest grade and `F` the lowest, with `N/A` shown for missing summaries. A detailed evaluation page has more information, a link to the summary, and evaluation notes. You can also see a detailed overview of scores for each section of the public summary.*
 
-—
+---
 
 The researchers have recently been in touch with the Apertus team, and made a series of recommendations, which include:
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -17,12 +17,12 @@ author: "Apertus Project"
 
 <div class="faq-item">
 <h4>What makes Apertus different from other open models?</h4>
-<p>Apertus is fully open — offering complete access to training data, code, and alignment principles, not just open weights. This openness supports research, collaboration and informed use, creating a valuable tool for the global AI community. See <a target="_blank" href="https://swiss-ai.org">Swiss AI Initiative</a>.</p>
+<p>Apertus is fully open, offering complete access to training data, code, and alignment principles, not just open weights. This openness supports research, collaboration and informed use, creating a valuable tool for the global AI community. See <a target="_blank" href="https://swiss-ai.org">Swiss AI Initiative</a>.</p>
 </div>
 
 <div class="faq-item">
 <h4>Can I use Apertus just like other AI systems?</h4>
-<p>Apertus is not a consumer product: this is foundational infrastructure. Designed to support innovation across research, education, government, and industry — while remaining aligned with Swiss and European values of transparency, neutrality, and accountability.
+<p>Apertus is not a consumer product: this is foundational infrastructure. Designed to support innovation across research, education, government, and industry, while remaining aligned with Swiss and European values of transparency, neutrality, and accountability.
 Many organizations are currently piloting solutions with the model, and we will update <a href="/pages/get-started/">our showcase</a> as new products based on Apertus become available. See also <a href="https://www.swissinfo.ch/eng/swiss-ai/fact-and-fiction-about-the-swiss-ai-model-apertus/90110034" target="_blank">swissinfo 10.2025</a>.
 </p>
 </div>

--- a/content/docs/guides/llamafile.md
+++ b/content/docs/guides/llamafile.md
@@ -13,7 +13,7 @@ author: "Apertus Project"
 
 [Llamafiles](https://docs.mozilla.ai/llamafile) are open-source AI models packaged as a single file, that runs on your laptop, offline.
 
-Built on top of [llama.cpp](https://github.com/ggerganov/llama.cpp), this enables **offline, cross-platform inference** with minimal setup—no Python, CUDA, or complex dependencies required. A Llamafile bundles:
+Built on top of [llama.cpp](https://github.com/ggerganov/llama.cpp), this enables **offline, cross-platform inference** with minimal setup: no Python, CUDA, or complex dependencies required. A Llamafile bundles:
 - The model weights (quantized for efficiency).
 - The inference engine (llama.cpp).
 - A built-in server for serving the model via a REST API.

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -6,7 +6,7 @@ title: "About"
 
 **Apertus is Switzerland's first large-scale, fully open, multilingual language model. Developed by researchers at ETH Zurich, EPFL, and the Swiss National Supercomputing Centre (CSCS), it represents a new approach to foundation model development: built by public institutions, designed for the public good.**
 
-The name comes from the Latin word for "open" — reflecting the model's defining characteristic. Unlike commercial models developed behind closed doors, Apertus makes its architecture, weights, training data, and methods fully accessible.
+The name comes from the Latin word for "open", reflecting the model's defining characteristic. Unlike commercial models developed behind closed doors, Apertus makes its architecture, weights, training data, and methods fully accessible.
 Please visit the <a href="/docs/faq">Frequently Asked Questions</a> and our [Documentation](/pages/documentation) section for details. 
 Use the [Contact page](/contact) to share ideas and questions with the Apertus team. 
 

--- a/content/pages/charter.md
+++ b/content/pages/charter.md
@@ -22,17 +22,17 @@ This charter sets forth principles for the alignment of artificial intelligence 
 ## Articles
 
 <ol class="articles-list">
-<li><strong>Response Quality</strong> — Writing clear, accurate, and useful responses.</li>
-<li><strong>Knowledge and Reasoning Standards</strong> — Using verified facts and sound reasoning.</li>
-<li><strong>Respectful Communication</strong> — Treating people with courtesy, fairness, and accessibility.</li>
-<li><strong>Preventing Harm</strong> — Protecting safety and refusing harmful requests.</li>
-<li><strong>Resolving Value Conflicts</strong> — Handling trade-offs openly and preserving principles.</li>
-<li><strong>Professional Competence Boundaries</strong> — Educating without giving licensed advice.</li>
-<li><strong>Collective Decision-Making</strong> — Supporting fair and constructive group decisions.</li>
-<li><strong>Autonomy and Personal Boundaries</strong> — Respecting choice, privacy, and clear limits.</li>
-<li><strong>Long-term Orientation and Sustainability</strong> — Considering long-term impacts and risks.</li>
-<li><strong>Human Agency</strong> — Keeping humans in control and independent.</li>
-<li><strong>AI Identity and Limits</strong> — Being clear about what the AI is and is not.</li>
+<li><strong>Response Quality</strong>: Writing clear, accurate, and useful responses.</li>
+<li><strong>Knowledge and Reasoning Standards</strong>: Using verified facts and sound reasoning.</li>
+<li><strong>Respectful Communication</strong>: Treating people with courtesy, fairness, and accessibility.</li>
+<li><strong>Preventing Harm</strong>: Protecting safety and refusing harmful requests.</li>
+<li><strong>Resolving Value Conflicts</strong>: Handling trade-offs openly and preserving principles.</li>
+<li><strong>Professional Competence Boundaries</strong>: Educating without giving licensed advice.</li>
+<li><strong>Collective Decision-Making</strong>: Supporting fair and constructive group decisions.</li>
+<li><strong>Autonomy and Personal Boundaries</strong>: Respecting choice, privacy, and clear limits.</li>
+<li><strong>Long-term Orientation and Sustainability</strong>: Considering long-term impacts and risks.</li>
+<li><strong>Human Agency</strong>: Keeping humans in control and independent.</li>
+<li><strong>AI Identity and Limits</strong>: Being clear about what the AI is and is not.</li>
 </ol>
 
 ---

--- a/content/pages/research.md
+++ b/content/pages/research.md
@@ -14,7 +14,7 @@ title: "Research"
   <a href="https://arxiv.org/abs/2509.14233" class="card" target="_blank">
     <img src="/images/pub/tech-report.jpg" align="left" height="80"/>
     <h4>Apertus: Democratizing Open and Compliant LLMs for Global Language Environments</h4>
-    <p>Main technical report — architecture, training methodology, data pipeline, evaluation.</p>
+    <p>Main technical report: architecture, training methodology, data pipeline, evaluation.</p>
   </a>
 </div>
 


### PR DESCRIPTION
Replaces all em dashes in content with commas, colons, or sentence breaks; the standalone em dash divider in the GPAI article becomes a markdown horizontal rule.