### PR TITLE
Set 1.5 article time to midnight so it publishes today

### DIFF
--- a/content/articles/2026-07-apertus-1-5/index.md
+++ b/content/articles/2026-07-apertus-1-5/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Apertus 1.5"
-date: 2026-07-24T10:00:00+01:00
+date: 2026-07-24T00:00:00+01:00
 draft: false
 author: "ETH EPFL CSCS"
 tags: ["Apertus", "Release", "Announcement"]


### PR DESCRIPTION
The article was stamped 10:00+01:00 which Hugo treats as future content until 11:00 CEST; midnight makes it build now.