### PR TITLE
Temporary FTP debug listing workflow

### DIFF
--- a/.github/workflows/ftp-debug.yml
+++ b/.github/workflows/ftp-debug.yml
@@ -1,0 +1,27 @@
+name: FTP debug listing
+on:
+  workflow_dispatch:
+jobs:
+  list:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Install lftp
+        run: sudo apt-get -qq update && sudo apt-get -qq --yes install lftp
+      - name: List remote directories
+        env:
+          FTP_HOST: ${{ secrets.DEPLOY_REMOTE_HOST }}
+          FTP_USER: ${{ secrets.DEPLOY_REMOTE_USER }}
+          FTP_PASS: ${{ secrets.DEPLOY_PRIVATE_KEY }}
+        run: |
+          lftp -e "
+          set ssl:verify-certificate false;
+          set net:max-retries 1;
+          set net:timeout 15;
+          open ftp://\$FTP_USER:\$FTP_PASS@\$FTP_HOST:21;
+          echo '=== pwd ==='; pwd;
+          echo '=== ls / ==='; cls -la /;
+          echo '=== ls . ==='; cls -la;
+          echo '=== ls /articles ==='; cls -l /articles || true;
+          echo '=== ls /pages ==='; cls -l /pages || true;
+          exit 0"


### PR DESCRIPTION
Dispatch-only, read-only directory listing to locate the real docroot for the FTP deploy. Will be removed once ftp.yml points at the right remote path.