### PR TITLE
Expand About roadmap: timeline with per-release details

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ hero_secondary_label: "Technical Information"
 hero_secondary_url: "/pages/documentation/"
 ---
 
-{{< columns cols="3" class="py-4 text-center" gap="5" >}}
+{{< columns cols="3" class="py-4 text-left" gap="5" >}}
 
 ### Fully Open
 
@@ -18,7 +18,7 @@ Training data, code, weights, methods, and alignment principles: all documented 
 
 ### Responsible at Scale
 
-Developed with the EU AI Act in mind: the model respects opt-outs, removes PII, and prevents memorization. A global foundation to build on.
+Ready for the EU AI Act: the model respects opt-outs, removes PII, and prevents memorization. A global foundation to build on.
 
 <--->
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -6,40 +6,15 @@ title: "About"
 
 **Apertus is Switzerland's first large-scale, fully open, multilingual language model. Developed by researchers at ETH Zurich, EPFL, and the Swiss National Supercomputing Centre (CSCS), it represents a new approach to foundation model development: built by public institutions, designed for the public good.**
 
-The name comes from the Latin word for "open", reflecting the model's defining characteristic. Unlike commercial models developed behind closed doors, Apertus makes its architecture, weights, training data, and methods fully accessible.
+The name comes from the Latin word for "open", reflecting the model's defining characteristic. Unlike commercial models developed behind closed doors, Apertus makes its architecture, weights, training data, and methods fully accessible. 
+
+Learn more about the [Apertus Roadmap](#roadmap) and [Swiss AI Initiative](#snai) in the following sections.
+
+---
+
+<a name="roadmap"></a>
 
 ## Roadmap
-
-<style>
-  .roadmap { margin: 2rem 0 1rem; }
-  .roadmap-item { position: relative; padding: 0 0 1.75rem 2.5rem; }
-  .roadmap-item::before {
-    content: ""; position: absolute; left: 7px; top: 20px; bottom: -4px;
-    width: 2px; background: #e5e7eb;
-  }
-  .roadmap-item:last-child::before { display: none; }
-  .roadmap-item::after {
-    content: ""; position: absolute; left: 0; top: 4px;
-    width: 16px; height: 16px; border-radius: 50%;
-    background: #49BED8; border: 3px solid #49BED8;
-  }
-  .roadmap-item.planned::after { background: #fff; border-color: #c0c4cc; }
-  .roadmap-item.latest .roadmap-content {
-    background: #f0f9fc; border: 1px solid #49BED8; border-radius: 12px;
-    padding: 1rem 1.25rem;
-  }
-  .roadmap-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem; }
-  .roadmap-title { font-size: 1.15rem; font-weight: 600; color: #1a1a1a; }
-  .roadmap-weights { font-size: 0.85rem; white-space: nowrap; }
-  .roadmap .badge-released { background: #d1fae5; color: #065f46; }
-  .roadmap .badge-latest { background: #dbeafe; color: #1e40af; }
-  .roadmap .badge-planned { background: #f3f4f6; color: #6b7280; }
-  .roadmap-item p { margin-bottom: 0; }
-  .roadmap-item ul { margin: 0; padding-left: 1.1rem; }
-  .roadmap-item li { margin-bottom: 0.35rem; }
-  .roadmap-item li:last-child { margin-bottom: 0; }
-  .roadmap-note { color: #9ca3af; font-size: 0.9rem; margin-bottom: 2.5rem; }
-</style>
 
 <div class="roadmap">
   <div class="roadmap-item" id="apertus-1-0">
@@ -103,6 +78,8 @@ Please visit the <a href="/docs/faq">Frequently Asked Questions</a> and our [Doc
 Use the [Contact page](/contact) to share ideas and questions with the Apertus team. 
 
 ---
+
+<a name="snai"></a>
 
 ## Swiss AI Initiative
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -8,13 +8,96 @@ title: "About"
 
 The name comes from the Latin word for "open", reflecting the model's defining characteristic. Unlike commercial models developed behind closed doors, Apertus makes its architecture, weights, training data, and methods fully accessible.
 
-##### Roadmap:
+## Roadmap
 
-- [Apertus 1.0 ⌾ 9.2025](/articles/2025-09-apertus-1-0/)
-- [Apertus 1.1 ⌾ 5.2026](/articles/2026-06-apertus-mini/)
-- **[Apertus 1.5 ⌾ 7.2026](/articles/2026-07-apertus-1-5/)**
-- Apertus 2.0 ⌾ Q1 2027
-- Apertus 2.5 ⌾ Q3 2027
+<style>
+  .roadmap { margin: 2rem 0 1rem; }
+  .roadmap-item { position: relative; padding: 0 0 1.75rem 2.5rem; }
+  .roadmap-item::before {
+    content: ""; position: absolute; left: 7px; top: 20px; bottom: -4px;
+    width: 2px; background: #e5e7eb;
+  }
+  .roadmap-item:last-child::before { display: none; }
+  .roadmap-item::after {
+    content: ""; position: absolute; left: 0; top: 4px;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #49BED8; border: 3px solid #49BED8;
+  }
+  .roadmap-item.planned::after { background: #fff; border-color: #c0c4cc; }
+  .roadmap-item.latest .roadmap-content {
+    background: #f0f9fc; border: 1px solid #49BED8; border-radius: 12px;
+    padding: 1rem 1.25rem;
+  }
+  .roadmap-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem; }
+  .roadmap-title { font-size: 1.15rem; font-weight: 600; color: #1a1a1a; }
+  .roadmap-weights { font-size: 0.85rem; white-space: nowrap; }
+  .roadmap .badge-released { background: #d1fae5; color: #065f46; }
+  .roadmap .badge-latest { background: #dbeafe; color: #1e40af; }
+  .roadmap .badge-planned { background: #f3f4f6; color: #6b7280; }
+  .roadmap-item p { margin-bottom: 0; }
+  .roadmap-item ul { margin: 0; padding-left: 1.1rem; }
+  .roadmap-item li { margin-bottom: 0.35rem; }
+  .roadmap-item li:last-child { margin-bottom: 0; }
+  .roadmap-note { color: #9ca3af; font-size: 0.9rem; margin-bottom: 2.5rem; }
+</style>
+
+<div class="roadmap">
+  <div class="roadmap-item" id="apertus-1-0">
+    <div class="roadmap-content">
+      <div class="roadmap-header">
+        <a class="roadmap-title" href="/articles/2025-09-apertus-1-0/">Apertus 1.0</a>
+        <span class="badge badge-released">Released · September 2025</span>
+        <a class="roadmap-weights" href="https://huggingface.co/collections/swiss-ai/apertus-v1-68b699e65415c231ace3b059" target="_blank" rel="noopener">Weights ↗</a>
+      </div>
+      <ul>
+        <li>Fully open: architecture, weights, training data, and methods all public, released under the Apache 2.0 licence, which allows commercial use.</li>
+        <li>Dense 8B and 70B models, among the largest fully open models available, with the 8B among the best dense models at the 8-10B scale.</li>
+        <li>Pretrained on over 1000 languages, using only data from public, versioned sources under open licences, with opt-outs respected for web data and a published, peer-reviewed mechanism that effectively prevents memorisation of training data.</li>
+        <li>Instruction following, aligned to the open values of the <a href="/pages/charter/">Apertus Charter</a>.</li>
+      </ul>
+    </div>
+  </div>
+  <div class="roadmap-item" id="apertus-1-1">
+    <div class="roadmap-content">
+      <div class="roadmap-header">
+        <a class="roadmap-title" href="/articles/2026-06-apertus-mini/">Apertus 1.1</a>
+        <span class="badge badge-released">Released · May 2026</span>
+        <a class="roadmap-weights" href="https://huggingface.co/collections/swiss-ai/apertus-mini-6a1ed4b1b7983e243a7e6e5a" target="_blank" rel="noopener">Weights ↗</a>
+      </div>
+      <p>Distillation of Apertus into 0.5B, 1.5B, and 4B models for mobile and browser deployment: competitive performance at a fraction of the training cost.</p>
+    </div>
+  </div>
+  <div class="roadmap-item latest" id="apertus-1-5">
+    <div class="roadmap-content">
+      <div class="roadmap-header">
+        <a class="roadmap-title" href="/articles/2026-07-apertus-1-5/">Apertus 1.5</a>
+        <span class="badge badge-latest">Latest release · July 2026</span>
+        <a class="roadmap-weights" href="https://huggingface.co/collections/swiss-ai/apertus-v15-6a63014ea6c937b7ecc6048a" target="_blank" rel="noopener">Weights ↗</a>
+      </div>
+      <p>A continuation of Apertus 1.0, and among the best fully open models at this scale for following instructions. Adds image understanding competitive with leading open-weight models at this scale, audio understanding, stronger tool use, and reasoning capability from our second-generation post-training pipeline. Stronger adherence to the <a href="/pages/charter/">Apertus Charter</a>.</p>
+    </div>
+  </div>
+  <div class="roadmap-item planned" id="apertus-2-0">
+    <div class="roadmap-content">
+      <div class="roadmap-header">
+        <span class="roadmap-title">Apertus 2.0</span>
+        <span class="badge badge-planned">Planned · Q1 2027</span>
+      </div>
+      <p>A magnitude larger model, developed to the same standard of transparency and trustworthiness: multimodal understanding, a more globally fair vocabulary, and more.</p>
+    </div>
+  </div>
+  <div class="roadmap-item planned" id="apertus-2-5">
+    <div class="roadmap-content">
+      <div class="roadmap-header">
+        <span class="roadmap-title">Apertus 2.5</span>
+        <span class="badge badge-planned">Planned · Q3 2027</span>
+      </div>
+      <p>Further development based on feedback from our partners and developers.</p>
+    </div>
+  </div>
+</div>
+
+<p class="roadmap-note"><em>Planned dates are targets and may shift.</em></p>
 
 Please visit the <a href="/docs/faq">Frequently Asked Questions</a> and our [Documentation](/pages/documentation) section for details. 
 Use the [Contact page](/contact) to share ideas and questions with the Apertus team. 

--- a/content/pages/charter.md
+++ b/content/pages/charter.md
@@ -7,8 +7,9 @@ title: "Apertus Charter"
 <p class="section-intro">The Apertus Charter defines alignment principles for AI systems developed under the Swiss AI Initiative, rooted in Switzerland's constitutional values and democratic traditions.</p>
 
 <div class="charter-meta">
-<strong>Version 1.0</strong><br>
-August 2025
+<p><i>(Previously referred to as the Swiss AI Charter)</i></p>
+<strong>Version 1.0</strong> &bull;
+August 2025 &bull; <a href="https://github.com/swiss-ai/apertus-charter/blob/main/charter-v1.0.md" target="_blank">Source</a>
 </div>
 
 ---

--- a/content/pages/documentation.md
+++ b/content/pages/documentation.md
@@ -5,9 +5,9 @@ title: "Documentation"
 ## Technical Information
 
 <p class="section-intro">
-  The <a href="/docs/faq">Frequently Asked Questions</a> cover common issues.
   See our <a href="/pages/research">Research collection</a> for an in-depth look at the architecture, training, data mix, and evaluation results.
-  Deployment &amp; compliance information follows:</p>
+  The <a href="/docs/faq">Frequently Asked Questions</a> cover many common issues.
+</p>
 
 <div class="card-grid">
   <a href="https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/USAGE_POLICY.pdf" class="card" style="text-decoration: none;">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -57,6 +57,7 @@
   .section-intro {
     color: #6b7280;
     margin-bottom: 4rem;
+    font-size: 110%;
     text-align: center;
   }
   .content-body p {
@@ -276,5 +277,34 @@
     width: 3.6rem;
     z-index: 10;
   }
+  /* Roadmap (About page) */
+  .roadmap { margin: 2rem 0 1rem; }
+  .roadmap-item { position: relative; padding: 0 0 1.75rem 2.5rem; }
+  .roadmap-item::before {
+    content: ""; position: absolute; left: 7px; top: 20px; bottom: -4px;
+    width: 2px; background: #e5e7eb;
+  }
+  .roadmap-item:last-child::before { display: none; }
+  .roadmap-item::after {
+    content: ""; position: absolute; left: 0; top: 4px;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #49BED8; border: 3px solid #49BED8;
+  }
+  .roadmap-item.planned::after { background: #fff; border-color: #c0c4cc; }
+  .roadmap-item.latest .roadmap-content {
+    background: #f0f9fc; border: 1px solid #49BED8; border-radius: 12px;
+    padding: 1rem 1.25rem;
+  }
+  .roadmap-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem; margin-bottom: 0.5rem; }
+  .roadmap-title { font-size: 1.15rem; font-weight: 600; color: #1a1a1a; }
+  .roadmap-weights { font-size: 0.85rem; white-space: nowrap; }
+  .roadmap .badge-released { background: #d1fae5; color: #065f46; }
+  .roadmap .badge-latest { background: #dbeafe; color: #1e40af; }
+  .roadmap .badge-planned { background: #f3f4f6; color: #6b7280; }
+  .roadmap-item p { margin-bottom: 0; }
+  .roadmap-item ul { margin: 0; padding-left: 1.1rem; }
+  .roadmap-item li { margin-bottom: 0.35rem; }
+  .roadmap-item li:last-child { margin-bottom: 0; }
+  .roadmap-note { color: #9ca3af; font-size: 0.9rem; margin-bottom: 2.5rem; }
 </style>
 {{ end }}


### PR DESCRIPTION
Reworks the roadmap section on the About page from a bare five-line list into a vertical timeline that says what makes each release special.

- Apertus 1.0: four bullets covering full openness + Apache 2.0, 8B/70B scale and performance, the 1000+ language / open-data / opt-out / anti-memorisation story, and charter alignment.
- Apertus 1.1: distillation into 0.5B, 1.5B, and 4B for mobile and browser deployment (sizes verified against the Hugging Face repos; the announcement article was already correct).
- Apertus 1.5: continuation of 1.0 with instruction following, image and audio understanding, tool use, and reasoning from the second-generation post-training pipeline; visually highlighted as the latest release.
- Apertus 2.0 / 2.5 kept coarse (planned badges, Q1/Q3 2027) with a note that planned dates may shift.

Presentation: timeline dots and connecting line, released/latest/planned status badges reusing the site's existing badge palette, "Weights" links to the three Hugging Face collections, links to the Apertus Charter, and per-release anchors (#apertus-1-5 etc.) for deep-linking. Styling is scoped to the page and matches the existing single.html conventions.

Preview tested locally with hugo server; charter and article links verified.