### PR TITLE
Fix accessibility: add alt text to partner logos and ARIA to nav toggler

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -70,7 +70,7 @@
     <a id="nav-brand" class="navbar-brand" href="/">
       <img src="{{ "images/apertvs.svg" | relURL }}" alt="Apertus" style="max-width: 95%; max-height: 18px">
     </a>
-    <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+    <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse justify-content-end" id="navbarNav">

--- a/layouts/partials/partners.html
+++ b/layouts/partials/partners.html
@@ -2,9 +2,9 @@
 
     <hr />
     <div class="row g-5 py-4 text-center">
-        <div class="col-12 col-md-4"><img src="/images/logos/epfl_ai_center_black.avif"></div>
-        <div class="col-12 col-md-4"><img src="/images/logos/eth_ai_center_logo.avif"></div>
-        <div class="col-12 col-md-4"><img src="/images/logos/cscs-logo.svg"></div>
+        <div class="col-12 col-md-4"><img src="/images/logos/epfl_ai_center_black.avif" alt="EPFL AI Center Logo"></div>
+        <div class="col-12 col-md-4"><img src="/images/logos/eth_ai_center_logo.avif" alt="ETH AI Center Logo"></div>
+        <div class="col-12 col-md-4"><img src="/images/logos/cscs-logo.svg" alt="CSCS Logo"></div>
     </div>
 
     <div class="row g-5 py-4 text-center">


### PR DESCRIPTION
## Disclaimer

I didn't use AI. This was a small thing :-) @loleg 

PS: to be fair. I use it to write the summary of the PR.


## What

Two small accessibility fixes flagged by the W3C Nu HTML validator and axe-style review of the homepage:

1. **Partner logos missing `alt` text** (`layouts/partials/partners.html`) — the EPFL, ETH and CSCS logo `<img>` tags had no `alt` attribute (the Swisscom logo already had one). Added descriptive alt text to all three.
2. **Nav toggler missing ARIA** (`layouts/partials/navbar.html`) — the `.navbar-toggler` button had no `aria-controls` / `aria-expanded` / `aria-label`, so screen readers announced an unlabeled button. Added the standard Bootstrap attributes.

## Why

- W3C validator reported: *"An `img` element must have an `alt` attribute"* (×3).
- The hamburger menu button was unlabeled for assistive tech.

Both are markup-only, no visual or behavioral change.

## Testing

Template-only edits (Hugo partials); no logic changed. Rendered output adds the missing attributes only.