### PR TITLE
Fix grammar and copy errors across pages and articles

### DIFF
--- a/content/articles/2026-04-acl/index.md
+++ b/content/articles/2026-04-acl/index.md
@@ -30,7 +30,7 @@ The report also includes safety considerations, warning that LLM models such as 
 
 The ACL 2026 invitation is a significant recognition of the Apertus project's technological prowess in global NLP academia. The conference, which accepts [around 20%](https://www.aclweb.org/aclwiki/Conference_acceptance_rates) from thousands of submitted papers, is considered a world-class venue for AI research.
 
-Our accepted paper is being presented at the [ACL 2026 Main Conference](https://2026.aclweb.org/) in San Diego on July 2-7, 2026, where the Apertus team looks forward to discuss their findings with the global research community. The research has already been [available as a pre-print](https://arxiv.org/abs/2509.14233) since the model release date, listed along with other relevant publications on our [Research page](/pages/research/).
+Our accepted paper is being presented at the [ACL 2026 Main Conference](https://2026.aclweb.org/) in San Diego on July 2-7, 2026, where the Apertus team looks forward to discussing their findings with the global research community. The research has already been [available as a pre-print](https://arxiv.org/abs/2509.14233) since the model release date, listed along with other relevant publications on our [Research page](/pages/research/).
 
 ### About Apertus
 

--- a/content/articles/2026-06-sme-circle/index.md
+++ b/content/articles/2026-06-sme-circle/index.md
@@ -11,13 +11,13 @@ comments: false
 
 #### Dive deeper into the world of open source with the Swiss AI Initiative. Our previous events from the series have highlighted that the AI our community wants is more than a technical solution. It is about exercising the right to understand what powers the tools we use every day.
 
-Our event at the ETH AI Center on June 17 was part of a platform of exchange with the wider community around the Swiss AI Initiative. Around seventy participants had a chance to see the latest use cases, learn about the research framework, and connect to the growing ecosystem around Apertus. The Swiss AI SME Circle is evolving into an execution-oriented ecosystem that brings together business, researchers, innovation partners, around a shared focus on locally impactful adoption of sovereign and transparent AI.
+Our event at the ETH AI Center on June 17 was part of a platform of exchange with the wider community around the Swiss AI Initiative. Around seventy participants had a chance to see the latest use cases, learn about the research framework, and connect to the growing ecosystem around Apertus. The Swiss AI SME Circle is evolving into an execution-oriented ecosystem that brings together businesses, researchers, and innovation partners around a shared focus on locally impactful adoption of sovereign and transparent AI.
 
 The SME Circle format is experiencing clear momentum, reflected in rising registrations (over a thousand newsletter subscribers, hundreds of attendees in our events), and an increasing number of direct requests for connections---both between participants and with the Apertus team. This indicates a shift from exploratory interest toward implementation-focused collaboration and real-world use cases.
 
 ![](image1.jpg)
 
-Bringing this case to point was a quick overview of the winners of the Spotlight award, announced last week at a premier business competition by Lea Firmin, CEO of [>>venture>>](https://www.venture.ch/). Among dozens of submissions, the most creative, high-impact applications of Apertus were recognized according to their innovation, technical excellence, and real-world impact. Learn more on their websites of the finalists [Noemon](https://www.noemon.com/), [Anyway Systems](https://www.anyway.dev/) and [Public AI Switzerland](https://publicai.ch/).
+Bringing this case to point was a quick overview of the winners of the Spotlight award, announced last week at a premier business competition by Lea Firmin, CEO of [>>venture>>](https://www.venture.ch/). Among dozens of submissions, the most creative, high-impact applications of Apertus were recognized according to their innovation, technical excellence, and real-world impact. Learn more on the websites of the finalists [Noemon](https://www.noemon.com/), [Anyway Systems](https://www.anyway.dev/) and [Public AI Switzerland](https://publicai.ch/).
 
 ![](image3.jpg)
 
@@ -31,7 +31,7 @@ For insights on the science of Apertus, we invited [Hanna](https://www.ayukh.com
 
 We also announced [Apertus Claritas](https://apertus-claritas.org/), a new open access platform with tech notes on the interpretability of large language models (LLMs). Look for more content here and subscribe to the [Inside Apertus](/subscribe/) newsletter for a regular look behind the scenes of the R&D project.
 
-There is lots to look forward to: and many challenges on the road ahead. We invited everyone to get ready to get a boost to their initiatives through our development program through a submission to our [Project Showcase](/showcase/). 
+There is a lot to look forward to, and many challenges on the road ahead. We invited everyone to get ready to get a boost to their initiatives through our development program through a submission to our [Project Showcase](/showcase/). 
 
 ![](image5.jpg)
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -88,4 +88,4 @@ Use the [Contact page](/contact) to share ideas and questions with the Apertus t
 The Initiative represents one of the world's largest open science efforts dedicated to AI foundation models. It pursues an open science approach to increase transparency and access for startups, SMEs, large companies, and the public sector in Switzerland and beyond.
 Please visit [swiss-ai.org](https://www.swiss-ai.org/) to learn more.
 
-_We are grateful to the support of all our strategic partners, members, and community._
+_We are grateful for the support of all our strategic partners, members, and community._

--- a/content/pages/documentation.md
+++ b/content/pages/documentation.md
@@ -79,5 +79,5 @@ title: "Documentation"
 </div>
 
 <p class="section-intro">
-    Fully open training infrastructure. We look forward to hear about your efforts to build on our models!
+    Fully open training infrastructure. We look forward to hearing about your efforts to build on our models!
 </p>

--- a/content/pages/research.md
+++ b/content/pages/research.md
@@ -65,13 +65,13 @@ title: "Research"
   <a href="https://arxiv.org/abs/2412.03304" class="card" target="_blank">
     <h4>Global MMLU: Multilingual Evaluation</h4>
     <div class="authors">Singh et al.</div>
-    <p>Understanding addressing cultural, linguistic biases.</p>
+    <p>Understanding and addressing cultural and linguistic biases.</p>
   </a>
   
   <a href="https://arxiv.org/abs/2505.20524" class="card" target="_blank">
     <h4>Towards Fully FP8 GEMM LLM Training at Scale</h4>
     <div class="authors">Hernández-Cano et al.</div>
-    <p>A new LLM architecture, enables unprecedented throughput gains.</p>
+    <p>A new LLM architecture that enables unprecedented throughput gains.</p>
   </a>
   
   <a href="https://arxiv.org/abs/2405.19279" class="card" target="_blank">


### PR DESCRIPTION
## Disclaimer (Human Written)

I was using OpenHands with Apertus to search for grammatical error. This was just a small experiment. Feel free to ignore if you don't like.

cc @loleg 

## What

Fixes eight grammar / copy errors in the site content (text-only, no layout or logic changes):

| File | Before → After |
|------|----------------|
| `content/pages/documentation.md` | "look forward to **hear**" → "look forward to **hearing**" |
| `content/articles/2026-04-acl/index.md` | "looks forward to **discuss**" → "looks forward to **discussing**" |
| `content/pages/research.md` | "**Understanding addressing** cultural, linguistic biases." → "Understanding **and** addressing cultural **and** linguistic biases." |
| `content/pages/research.md` | "A new LLM architecture**,** enables…" → "A new LLM architecture **that** enables…" |
| `content/pages/about.md` | "grateful **to** the support" → "grateful **for** the support" |
| `content/articles/2026-06-sme-circle/index.md` | "**There is lots** to look forward **to: and** many challenges" → "**There is a lot** to look forward **to, and** many challenges" |
| `content/articles/2026-06-sme-circle/index.md` | "**their** websites of the finalists" → "**the** websites of the finalists" |
| `content/articles/2026-06-sme-circle/index.md` | "business, researchers, innovation partners**,** around" → "**businesses**, researchers**, and** innovation partners around" |

## Why

These are grammatical errors (wrong verb forms after "look forward to", a missing conjunction, a stray comma creating a sentence fragment, a wrong preposition, subject/verb number, and a misused colon) found while reviewing the live site copy.

## Notes

- Content-only edits; no templates, styling, or links changed.
- Deliberately left alone: paper/collection *titles* quoted verbatim, and a few stylistic-but-defensible items (e.g. "Login" on the Get Started page, "case in point" phrasing).