### PR TITLE
Minor updates

### DIFF
--- a/content/articles/2026-07-apertus-1-5/index.md
+++ b/content/articles/2026-07-apertus-1-5/index.md
@@ -53,6 +53,7 @@ Join the discussion in the community forums on Hugging Face and GitHub. At our r
 - [The State of the Art in Open Source AI for Swiss Legal Tasks](https://github.com/JoelNiklaus/SwissLegalEvals/blob/main/blog/swiss-legal-evals-2026.md#the-state-of-the-art-in-open-source-ai-for-swiss-legal-tasks) - Joel Niklaus - 4.8.2026
 - [Helvetra moves to Apertus 1.5: what changes, and what we're watching](https://www.helvetra.ch/news/apertus-1-5-what-it-means-for-helvetra) - 4.8.2026
 - [Shrinking Apertus 1.5 8B for an 8 GB Laptop GPU](https://digitalpathlines.ch/2026/08/12/shrinking-apertus-1-5-8b-for-an-8-gb-laptop-gpu/) - Emmanuel Belo - 12.8.2026
+- [Apertus 1.5 - first impressions from using Switzerland’s updated AI model](https://www.liip.ch/en/blog/apertus-1-5-first-impressions-from-using-switzerland-s-updated-ai-model) - Josef Kruckenberg - 26.8.2026
 
 #### \* * * * *
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -58,7 +58,7 @@ Learn more about the [Apertus Roadmap](#roadmap) and [Swiss AI Initiative](#snai
         <span class="roadmap-title">Apertus 2.0</span>
         <span class="badge badge-planned">Planned · Q1 2027</span>
       </div>
-      <p>A magnitude larger model, developed to the same standard of transparency and trustworthiness: multimodal understanding, a more globally fair vocabulary, and more.</p>
+      <p>A magnitude larger scale of model, developed to the same standard of transparency and trustworthiness: a more globally fair vocabulary, and more.</p>
     </div>
   </div>
   <div class="roadmap-item planned" id="apertus-2-5">

--- a/content/pages/documentation.md
+++ b/content/pages/documentation.md
@@ -10,7 +10,7 @@ title: "Documentation"
 </p>
 
 <div class="card-grid">
-  <a href="https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/USAGE_POLICY.pdf" class="card" style="padding: 1rem" target="_blank">
+  <a href="https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/USAGE_POLICY.pdf" class="card" style="padding: 1rem" target="_blank">
     <h4>Apertus 1.5 Usage Policy</h4>
     <p>Terms and conditions for model use</p>
   </a>
@@ -18,11 +18,11 @@ title: "Documentation"
     <h4>Apertus Charter</h4>
     <p>The values and principles that guide Apertus</p>
   </a>
-  <a href="https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/Apertus_1_5_EU_Public_Summary.pdf" class="card" style="padding: 1rem" target="_blank">
+  <a href="https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/Apertus_1_5_EU_Public_Summary.pdf" class="card" style="padding: 1rem" target="_blank">
     <h4>EU Public Summary</h4>
     <p>Public summary for EU AI Act compliance</p>
   </a>
-  <a href="https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/Apertus_1_5_EU_Code_of_Practice.pdf" class="card" style="padding: 1rem" target="_blank">
+  <a href="https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/Apertus_1_5_EU_Code_of_Practice.pdf" class="card" style="padding: 1rem" target="_blank">
     <h4>EU Code of Practice</h4>
     <p>Code of practice documentation</p>
   </a>

--- a/content/pages/legal.md
+++ b/content/pages/legal.md
@@ -4,13 +4,13 @@ title: "Legal Notice"
 
 # Legal Notice for Models
 
-- [Apertus LLM Acceptable Use Policy (AUP)](https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/USAGE_POLICY.pdf)
-- [Apache 2.0 License](https://huggingface.co/swiss-ai/Apertus-v1.5-70B/blob/main/LICENSE.txt)
+- [Apertus LLM Acceptable Use Policy (AUP)](https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/USAGE_POLICY.pdf)
+- [Apache 2.0 License](https://github.com/swiss-ai/apertus-legal/blob/main/apertus_1.5/LICENSE.txt)
 
 #### Transparency Documentation and Code of Practice
 
--   [Apertus 1.5 EU Public Summary](https://github.com/swiss-ai/apertus-legal/blob/main/apertus_1.5/Apertus_1_5_EU_Public_Summary.pdf)
--   [Apertus 1.5 EU Code of Practice](https://github.com/swiss-ai/apertus-legal/blob/main/apertus_1.5/Apertus_1_5_EU_Code_of_Practice.pdf)
+-   [Apertus 1.5 EU Public Summary](https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/Apertus_1_5_EU_Public_Summary.pdf)
+-   [Apertus 1.5 EU Code of Practice](https://github.com/swiss-ai/apertus-legal/raw/main/apertus_1.5/Apertus_1_5_EU_Code_of_Practice.pdf)
 
 #### Data Protection and Copyright Requests
 


### PR DESCRIPTION
- Fix links to public summary and other docs, to use GitHub raw links instead of HF (issues due to gating)
- Quick fix to the about page, link to article on Apertus 1.5 release